### PR TITLE
Fix autogenerated changelog to pass ci pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,3 @@ CHANGELOG
 ------------------
 
 Initial release as namespace plugin
-


### PR DESCRIPTION
The release bot adds an empty line at the end of the changelog file. This is not valid to pass the CI pipeline. This PR fixes the issue.