### PR TITLE
Bump dependency Pillow to 9.0.1+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 python = ">=3.6.2,<4.0"
 pelican = ">=4.5"
 piexif = {version = "^1.1.3", optional = true}
-Pillow = "^8.2.0"
+Pillow = ">=9.0.1,<10.0"
 
 [tool.poetry.dev-dependencies]
 black = "^22"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 "Issue Tracker" = "https://github.com/pelican-plugins/photos/issues"
 
 [tool.poetry.dependencies]
-python = ">=3.6.2,<4.0"
+python = ">=3.7,<4.0"
 pelican = ">=4.5"
 piexif = {version = "^1.1.3", optional = true}
 Pillow = ">=9.0.1,<10.0"


### PR DESCRIPTION
Some CVEs have been fixed in Pillow 8.3.x and 9.0.x so we bump the version from 8.2 to 9.0.1+

See: https://github.com/python-pillow/Pillow/blob/main/CHANGES.rst

This fixes #46 