### PR TITLE
Inline image and lightbox template files

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,14 @@ The plug-in resizes the referred photos, and generates thumbnails for galleries 
 With this feature, a gallery could be placed everywhere in an article.
 
 `PHOTO_INLINE_GALLERY_PATTERN`
-: The pattern to look for. The ```gallery_name``` is used to find the right gallery.
+: The pattern to look for. The ```gallery_name``` is used to find the right gallery
+and the optional ``options`` is used to transmit options to the ``inline_gallery.html``
+template file.
 
 Defaults:
 
 ```python
-r"gallery::(?P<gallery_name>[/{}\w_-]+)"
+r"gallery(\[(?P<options>[\w,=]+)\])?::(?P<gallery_name>[/{}\w_-]+)"
 ```
 
 `PHOTO_INLINE_GALLERY_TEMPLATE`
@@ -250,6 +252,53 @@ An example of this file is:
     {% endfor %}
 </div>
 ```
+
+The `PHOTO_INLINE_GALLERY_PATTERN`
+variable in the ``pelicanconf.py`` file defined the pattern to look for both the
+```gallery_name``` and the ``options``, used to transmit options
+to the ``inline_gallery.html`.
+Its default value is
+
+```python
+r"gallery(\[(?P<options>[\w,=]+)\])?::(?P<gallery_name>[/{}\w_-]+)"
+```
+An inline gallery transmitting an option
+is introduced in Markdown or in reStructuredText as:
+
+```
+  gallery[reverse]::{photo}mygallery
+```
+
+The ``"inline_gallery.html"``` template file is then modified
+accordingly to take into accound this option:
+
+```html
+<div class="gallery">
+    {% if options and options['reverse'] %}
+      {% set use_reverse = True %}
+    {% else %}
+      {% set use_reverse = False %}
+    {% endif %}
+    {% for title, gallery in galleries%}
+        <h1>{{ title }}</h1>
+            {% for name, photo, thumb, exif, caption in (gallery | sort(reverse=use_reverse,attribute="filename")) %}
+                    <a href="{{ SITEURL }}/{{ photo }}" title="{{ name }}" exif="{{ exif }}" caption="{{ caption }}"><img src="{{ SITEURL }}/{{ thumb }}"></a>
+            {% endfor %}
+    {% endfor %}
+</div>
+```
+
+The ``options`` variable is a python ``dict``:
+it it is defined as a coma-separated list of ``keys``
+and ``value`` pairs, e.g.
+
+```
+  gallery[reverse,width=20em]::{photo}mygallery
+```
+
+When there is no explicit value, the value is a ``bool``, set to ``True``.
+When the value is explicitely ``False``, it is also converted to ``bool``,
+otherwise it is left as a ``string``.
 
 ### Inline image
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The plug-in resizes the referred photos, and generates thumbnails for galleries 
 
 `PHOTO_INLINE_GALLERY_ENABLED`
 : Enable inline gallery processing. (Default: False)
+With this feature, a gallery could be placed everywhere in an article.
 
 `PHOTO_INLINE_GALLERY_PATTERN`
 : The pattern to look for. The ```gallery_name``` is used to find the right gallery.
@@ -219,6 +220,133 @@ For example, add the following to the template `index.html`, inside the `entry-c
 	style="display: inline; float: right; margin: 2px 0 2ex 4ex;" /></a>
 {% endif %}
 ```
+
+## The new optional templates files for inline galleries, images and lightboxes
+
+There are three corresponding template files.
+
+### Inline gallery
+
+When the variable `PHOTO_INLINE_GALLERY_TEMPLATE` is set to true,
+a gallery could be placed everywhere in an article.
+An inline gallery is introduced in Markdown as:
+
+```
+  gallery::{photo}mygallery
+```
+
+The `PHOTO_INLINE_GALLERY_PATTERN` variable allows change the
+pattern used to recognize an inline gallery in an article.
+The default corresponds to:
+
+```python
+  PHOTO_INLINE_GALLERY_PATTERN = r"gallery::(?P<gallery_name>[/{}\w_-]+)"
+```
+
+It could be changed e.g. as
+```python
+  PHOTO_INLINE_GALLERY_PATTERN = r"..[ \t]+gallery=(?P<gallery_name>[/{}\w_-]+)"
+```
+
+and then, an inlined gallery could be introduced in reStructuredText as:
+
+```
+..  gallery={photo}mygallery
+```
+
+The template file to render inline galleries is loaded.
+The name of this file is by default ``"inline_gallery.html"```
+and could be changed with the  `PHOTO_INLINE_GALLERY_TEMPLATE`  variable.
+The substituted variable is `gallery` which is the previous tuple with five elements.
+An example of this file is:
+```html
+<div class="gallery">
+    {% for title, gallery in galleries%}
+        <h1>{{ title }}</h1>
+            {% for name, photo, thumb, exif, caption in gallery %}
+                    <a href="{{ SITEURL }}/{{ photo }}" title="{{ name }}" exif="{{ exif }}" caption="{{ caption }}"><img src="{{ SITEURL }}/{{ thumb }}"></a>
+            {% endfor %}
+    {% endfor %}
+</div>
+```
+
+### Inline image
+
+An inlined image is introduced in Markdown as:
+
+```
+  ![alttext]({image}mygallery/myimage.jpg){height=1.2em}
+```
+
+or in reStructuredText as:
+
+```
+  .. |mylabel| image:: {photo}mygallery/myimage.jpg
+            :height: 1.2em
+
+  And then, it could be inserted |mylabel| everywhere in the text.
+```
+
+Inlined images are rendered by default using an internal template scheme.
+This could be customized by providing a template file.
+The name of this file is by default ``"inline_image.html"```
+and could be changed with the  `PHOTO_INLINE_IMAGE_TEMPLATE`  variable.
+When this file is founded, it replaces the default internal template.
+An example of this file is:
+```html
+  <{{ tag }} {{ attributes_before }} {{ src }}="{{ SITEURL }}/{{ image_article }}" {{ attributes_after }}
+```
+The content of this example file corresponds exactly to the internal default behavior
+and could be customized. The substituted variables are:
+
+  * `SITEURL` : the propagated variable from `pelicanconf.py` or ``"."``
+     when `RELATIVE_URLS` is set to `True`.
+  * `gallery_name` : the title of the gallery
+  * `image_source` : the output path to the original photo
+  * `image_article` : the output path to the generated photo
+  * `caption` : the caption of the photo, as read from `captions.txt`
+  * `tag` : the tag, e.g. `img`
+  * `src` : the source keyword, e.g. `src`
+  * `attributes_before` : attribute list that comes before the `src`
+  * `attributes_after` : attribute list that comes after the `src`
+  * `extra_attributes` : others attributes
+
+### Inline lightbox
+
+Similarly to inlined images, an inlined lightbox is introduced in Markdown as:
+
+```
+  ![alttext]({lightbox}mygallery/myimage.jpg){width=15%}
+```
+
+or in reStructuredText as:
+
+```
+  .. |mylabel| image:: {lightbox}mygallery/myimage.jpg
+            :width: 15%
+
+  And then, it could be inserted as:
+
+  |mylabel|
+```
+
+Inlined lighboxes are also rendered by default using an internal template scheme
+and this could be customized by providing a template file.
+The name of this file is by default ``"inline_lighbox.html"```
+and could be changed with the  `PHOTO_INLINE_LIGHTBOX_TEMPLATE`  variable.
+When this file is founded, it replaces the default internal template.
+An example of this file is:
+```html
+<a href="{{ SITEURL }}/{{ image_source }}" data-lightbox="{{ gallery_name}}" data-title="{{ caption}}">
+  <{{ tag }} {{ attributes_before }} {{ src }}="{{ SITEURL }}/{{ image_thumb }}" {{ attributes_after }}
+</a>
+```
+
+The content of this example file corresponds exactly to the internal default behavior
+and could be customized. The substituted variables are the same as for the
+inlined images, with, in addition:
+
+  * `image_gthumb` : the output path to the generated thumbnail.
 
 ## How to make the gallery lightbox
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ and could be customized. The substituted variables are:
   * `gallery_name` : the title of the gallery
   * `image_source` : the output path to the original photo
   * `image_article` : the output path to the generated photo
+  * `exif` : the EXIF information of the photo, as read from the file `exif.txt`
   * `caption` : the caption of the photo, as read from `captions.txt`
   * `tag` : the tag, e.g. `img`
   * `src` : the source keyword, e.g. `src`

--- a/README.md
+++ b/README.md
@@ -229,29 +229,10 @@ There are three corresponding template files.
 
 When the variable `PHOTO_INLINE_GALLERY_TEMPLATE` is set to true,
 a gallery could be placed everywhere in an article.
-An inline gallery is introduced in Markdown as:
+An inline gallery is introduced in Markdown or in reStructuredText as:
 
 ```
   gallery::{photo}mygallery
-```
-
-The `PHOTO_INLINE_GALLERY_PATTERN` variable allows change the
-pattern used to recognize an inline gallery in an article.
-The default corresponds to:
-
-```python
-  PHOTO_INLINE_GALLERY_PATTERN = r"gallery::(?P<gallery_name>[/{}\w_-]+)"
-```
-
-It could be changed e.g. as
-```python
-  PHOTO_INLINE_GALLERY_PATTERN = r"..[ \t]+gallery=(?P<gallery_name>[/{}\w_-]+)"
-```
-
-and then, an inlined gallery could be introduced in reStructuredText as:
-
-```
-..  gallery={photo}mygallery
 ```
 
 The template file to render inline galleries is loaded.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: minor
+
+- support for optional `inline_image.html` and `image_lightbox.html` templates
+- `SITEURL` is now well substituted in all the `inline_xxx.html` templates
+- added in the `README.md` file some documentation for these new features
+- contributed by Pirogh <pierre.saramito@imag.fr>

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,5 +2,7 @@ Release type: minor
 
 - support for optional `inline_image.html` and `image_lightbox.html` templates
 - `SITEURL` is now well substituted in all the `inline_xxx.html` templates
+- the PHOTO_INLINE_GALLERY_PATTERN python regex also define an "options"
+  dict that is transmitted to the inline_gallery.html template file
 - added in the `README.md` file some documentation for these new features
 - contributed by Pirogh <pierre.saramito@imag.fr>

--- a/examples/themes/notmyidea_photos/templates/inline_image.html
+++ b/examples/themes/notmyidea_photos/templates/inline_image.html
@@ -1,0 +1,3 @@
+<!-- >>>> Start >>>>> PHOTO plugin: inline image >>>>>>>>> -->
+<{{ tag }} {{ attributes_before }} {{ src }}="{{ SITEURL }}/{{ image_article }}" {{ attributes_after }}
+<!-- <<<< End <<<<< PHOTO plugin: inline image <<<<<<<<< -->

--- a/examples/themes/notmyidea_photos/templates/inline_lightbox.html
+++ b/examples/themes/notmyidea_photos/templates/inline_lightbox.html
@@ -1,0 +1,5 @@
+<!-- >>>> Start >>>>> PHOTO plugin: inline lightbox >>>>>>>>> -->
+<a href="{{ SITEURL }}/{{ image_source }}" data-lightbox="{{ gallery_name}}" data-title="{{ caption}}">
+  <{{ tag }} {{ attributes_before }} {{ src }}="{{ SITEURL }}/{{ image_thumb }}" {{ attributes_after }}
+</a>
+<!-- >>>> end >>>>> PHOTO plugin: inline lightbox >>>>>>>>> -->

--- a/pelican/plugins/photos/photos.py
+++ b/pelican/plugins/photos/photos.py
@@ -2178,6 +2178,7 @@ def replace_inline_images(content, inline_images):
                 template_values["caption"] = str(image.caption)
             else:
                 template_values["caption"] = ""
+            template_values["exif"] = image.image.exif
             gallery_name = value.split("/")[0]
             template_values["gallery_name"] = gallery_name
             template_values["tag"] = m.group("tag")


### PR DESCRIPTION
Hi all !

In brief:
- support for optional "inline_image.html" and "image_lightbox.html" templates
- SITEURL is now replaced in all "inline_*.html" templates

In order to increase the flexibility of inline images and lightboxes,
I've introduced two template file provided by default as:
  PHOTO_INLINE_IMAGE_TEMPLATE     = "inline_image.html"
  PHOTO_INLINE_LIGHTBOX_TEMPLATE  = "image_lightbox.html"
Indeed, these two files was suggested in the photos.py code,
but not used in practice: perhaps it was planed for future works?
This is now achieved and the README.md doc is completed accordingly.

Also, the SITEURL variable was not propagated in "inline_gallery.html"
ind thus, it was complicated to compute full path files.
Now, SITEURL is propagated in this template file
and, moreover, it honors the RELATIVE_URLS variable from pelicanconf.py:
when RELATIVE_URLS is True, then SITEURL is propagated as ".".

Pirogh <pierre.saramito@imag.fr>