### PR TITLE
Update the default gallery, article, and thumb config

### DIFF
--- a/pelican/plugins/photos/photos.py
+++ b/pelican/plugins/photos/photos.py
@@ -1534,9 +1534,24 @@ def initialized(pelican: Pelican):
     global g_process_pool
     p = os.path.expanduser("~/Pictures")
     DEFAULT_CONFIG.setdefault("PHOTO_LIBRARY", p)
-    DEFAULT_CONFIG.setdefault("PHOTO_GALLERY", (1024, 768, 80))
-    DEFAULT_CONFIG.setdefault("PHOTO_ARTICLE", (760, 506, 80))
-    DEFAULT_CONFIG.setdefault("PHOTO_THUMB", (192, 144, 60))
+    DEFAULT_CONFIG.setdefault("PHOTO_GALLERY", {
+        "width": 1024,
+        "height": 768,
+        "type": "jpeg",
+        "options": {"quality": 80},
+    })
+    DEFAULT_CONFIG.setdefault("PHOTO_ARTICLE", {
+        "width": 760,
+        "height": 506,
+        "type": "jpeg",
+        "options": {"quality": 80},
+    })
+    DEFAULT_CONFIG.setdefault("PHOTO_THUMB", {
+        "width": 192,
+        "height": 144,
+        "type": "jpeg",
+        "options": {"quality": 60},
+    })
     DEFAULT_CONFIG.setdefault("PHOTO_SQUARE_THUMB", False)
     DEFAULT_CONFIG.setdefault("PHOTO_GALLERY_TITLE", "")
     DEFAULT_CONFIG.setdefault("PHOTO_ALPHA_BACKGROUND_COLOR", (255, 255, 255))

--- a/pelican/plugins/photos/photos.py
+++ b/pelican/plugins/photos/photos.py
@@ -1537,28 +1537,34 @@ def initialized(pelican: Pelican):
     DEFAULT_CONFIG.setdefault(
         "PHOTO_GALLERY",
         {
-            "width": 1024,
-            "height": 768,
-            "type": "jpeg",
-            "options": {"quality": 80},
+            "default": {
+                "width": 1024,
+                "height": 768,
+                "type": "jpeg",
+                "options": {"quality": 80},
+            }
         },
     )
     DEFAULT_CONFIG.setdefault(
         "PHOTO_ARTICLE",
         {
-            "width": 760,
-            "height": 506,
-            "type": "jpeg",
-            "options": {"quality": 80},
+            "default": {
+                "width": 760,
+                "height": 506,
+                "type": "jpeg",
+                "options": {"quality": 80},
+            }
         },
     )
     DEFAULT_CONFIG.setdefault(
         "PHOTO_THUMB",
         {
-            "width": 192,
-            "height": 144,
-            "type": "jpeg",
-            "options": {"quality": 60},
+            "default": {
+                "width": 192,
+                "height": 144,
+                "type": "jpeg",
+                "options": {"quality": 60},
+            }
         },
     )
     DEFAULT_CONFIG.setdefault("PHOTO_SQUARE_THUMB", False)
@@ -1581,6 +1587,39 @@ def initialized(pelican: Pelican):
 
     if pelican:
         pelican.settings.setdefault("PHOTO_LIBRARY", p)
+        pelican.settings.setdefault(
+            "PHOTO_GALLERY",
+            {
+                "default": {
+                    "width": 1024,
+                    "height": 768,
+                    "type": "jpeg",
+                    "options": {"quality": 80},
+                }
+            },
+        )
+        pelican.settings.setdefault(
+            "PHOTO_ARTICLE",
+            {
+                "default": {
+                    "width": 760,
+                    "height": 506,
+                    "type": "jpeg",
+                    "options": {"quality": 80},
+                }
+            },
+        )
+        pelican.settings.setdefault(
+            "PHOTO_THUMB",
+            {
+                "default": {
+                    "width": 192,
+                    "height": 144,
+                    "type": "jpeg",
+                    "options": {"quality": 60},
+                }
+            },
+        )
         pelican.settings.setdefault("PHOTO_GALLERY", (1024, 768, 80))
         pelican.settings.setdefault("PHOTO_ARTICLE", (760, 506, 80))
         pelican.settings.setdefault("PHOTO_THUMB", (192, 144, 60))

--- a/pelican/plugins/photos/photos.py
+++ b/pelican/plugins/photos/photos.py
@@ -1534,24 +1534,33 @@ def initialized(pelican: Pelican):
     global g_process_pool
     p = os.path.expanduser("~/Pictures")
     DEFAULT_CONFIG.setdefault("PHOTO_LIBRARY", p)
-    DEFAULT_CONFIG.setdefault("PHOTO_GALLERY", {
-        "width": 1024,
-        "height": 768,
-        "type": "jpeg",
-        "options": {"quality": 80},
-    })
-    DEFAULT_CONFIG.setdefault("PHOTO_ARTICLE", {
-        "width": 760,
-        "height": 506,
-        "type": "jpeg",
-        "options": {"quality": 80},
-    })
-    DEFAULT_CONFIG.setdefault("PHOTO_THUMB", {
-        "width": 192,
-        "height": 144,
-        "type": "jpeg",
-        "options": {"quality": 60},
-    })
+    DEFAULT_CONFIG.setdefault(
+        "PHOTO_GALLERY",
+        {
+            "width": 1024,
+            "height": 768,
+            "type": "jpeg",
+            "options": {"quality": 80},
+        },
+    )
+    DEFAULT_CONFIG.setdefault(
+        "PHOTO_ARTICLE",
+        {
+            "width": 760,
+            "height": 506,
+            "type": "jpeg",
+            "options": {"quality": 80},
+        },
+    )
+    DEFAULT_CONFIG.setdefault(
+        "PHOTO_THUMB",
+        {
+            "width": 192,
+            "height": 144,
+            "type": "jpeg",
+            "options": {"quality": 60},
+        },
+    )
     DEFAULT_CONFIG.setdefault("PHOTO_SQUARE_THUMB", False)
     DEFAULT_CONFIG.setdefault("PHOTO_GALLERY_TITLE", "")
     DEFAULT_CONFIG.setdefault("PHOTO_ALPHA_BACKGROUND_COLOR", (255, 255, 255))


### PR DESCRIPTION
The configurations in these defaults are converted to a dict with an INFO logged warning shortly after setting these defaults, so this change removes some spurious logging due to the legacy default values