### PR TITLE
photos: eplace SITEURL in template of inline_gallery.html

### DIFF
--- a/pelican/plugins/photos/photos.py
+++ b/pelican/plugins/photos/photos.py
@@ -2069,6 +2069,7 @@ def replace_inline_galleries(content, inline_galleries):
         )
         template_values = {
             "galleries": galleries,
+            "SITEURL": pelican_settings["SITEURL"],
         }
         if isinstance(content, Article):
             template_values["article"] = content


### PR DESCRIPTION
Template from examples/ sets image path as \{\{ SITEURL \}\}/\{\{ photo \}\} however it wasn't replaced.

My solution is extremely simple and rather not dedicated for production work so feel free to close my PR and fix this someway else