### PR TITLE
Increment Pillow minimum version to address security issue

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Bump python and pillow minimum package version to fix [security issues](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.1.html)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,0 @@
-Release type: minor
-
-Bump python and pillow minimum package version to fix [security issues](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.1.html)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,10 @@ classifiers = [
 "Issue Tracker" = "https://github.com/pelican-plugins/photos/issues"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<4.0"
+python = ">=3.8,<4.0"
 pelican = ">=4.5"
 piexif = {version = "^1.1.3", optional = true}
-Pillow = ">=9.0.1,<10.0"
+Pillow = ">=10.0.1"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23"


### PR DESCRIPTION
Due to [security issues](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.1.html) in Pillow package, we must bump the minimum required version.

As a consequence, we must also bump the minimum python version to v3.8 because pillow v10.0.1 requires python v3.8 at minimum.

This commit will improve the overall security and future maintenance of pelican-photos plugin.