### PR TITLE
Actually use Python version matrix in CI tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python & PDM
+      - name: Set up Python ${{ matrix.python-version }} & PDM
         uses: pdm-project/setup-pdm@v3
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
           cache: true
           cache-dependency-path: ./pyproject.toml
 
@@ -54,7 +54,6 @@ jobs:
       - name: Install dependencies
         run: pdm install
 
-      # Disabled until the code can be made ruff-compatible
       - name: Run linters
         run: pdm run invoke lint --diff
 
@@ -75,7 +74,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Check release
         id: check_release


### PR DESCRIPTION
Previously, Python 3.10 was hardcoded in the `tests` CI job, causing the test matrix to use that same 3.10 version even for test runs labeled with 3.8, 3.9, 3.11, and 3.12.

This fixes that problem, seemingly unearthing a test error on Python 3.8 related to recently-applied Ruff formatting. (cc: @offbyone)