### PR TITLE
Remove unneeded dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,21 +43,17 @@ markdown = [
     "markdown"
 ]
 
-
 [tool.pdm.dev-dependencies]
-dev = [
-    "black",
-    "flake8",
-    "flake8-black",
-    "invoke",
-    "ruff",
-    "markdown",
-    "pytest",
-    "pytest-cov",
-    "pytest-xdist",
-    "pytest-sugar",
+lint = [
+    "invoke>=2.2.0",
+    "ruff>=0.1.3",
 ]
-
+test = [
+    "markdown>=3.4",
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+    "pytest-sugar>=0.9.7",
+]
 
 [tool.autopub]
 project-name = "Photos"


### PR DESCRIPTION
Also, separate the rest into dependency groups and set minimum versions.