### PR TITLE
Use forked `githubrelease` as temporary CI fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }} & PDM
         uses: pdm-project/setup-pdm@v3
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Validate links in Markdown files
         uses: JustinBeckwith/linkinator-action@v1
@@ -69,7 +69,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -79,8 +79,8 @@ jobs:
       - name: Check release
         id: check_release
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install autopub[github]
+          python -m pip install autopub
+          python -m pip install https://github.com/autopub/github-release/archive/pyproject.zip
           autopub check
 
       - name: Publish


### PR DESCRIPTION
Until either (1) the `githubrelease` project ships a new release with the fix we need, or (2) the `githubrelease` module is vendored into AutoPub itself, we need this temporary measure to use the implicit `GITHUB_TOKEN` environment variable.

Related issues:

- https://github.com/pelican-plugins/photos/pull/99
- https://github.com/j0057/github-release/pull/73
- https://github.com/autopub/autopub/issues/42