### PR TITLE
Add SITEURL to template context

### DIFF
--- a/pelican/plugins/photos/photos.py
+++ b/pelican/plugins/photos/photos.py
@@ -149,7 +149,10 @@ class Profile:
             tpl_name = default_template_name
         if tpl_name is None:
             logger.error("Unable to find template for profile")
-        return g_generator.get_template(tpl_name).render(**kwargs)
+
+        context_vars = {"SITEURL": pelican_settings["SITEURL"]}
+        context_vars.update(kwargs)
+        return g_generator.get_template(tpl_name).render(**context_vars)
 
     @property
     def file_suffix(self) -> str:


### PR DESCRIPTION
We render our own templates so we have to add the SITEURL var to the context. This fixes #87 