### PR TITLE
Upgrade Ruff linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.0
+    rev: v0.3.2
     hooks:
       - id: ruff
       - id: ruff-format

--- a/pelican/plugins/photos/photos.py
+++ b/pelican/plugins/photos/photos.py
@@ -1750,7 +1750,7 @@ def enqueue_image(img: Image) -> Image:
         or g_image_cache[img.dst].spec != img.spec
     ):
         raise InternalError(
-            "resize conflict for {}, {}-{} is not {}-{}".format(
+            "Resize conflict for {}, {}-{} is not {}-{}".format(  # noqa: UP032
                 img.dst,
                 g_image_cache[img.dst].source_image.filename,
                 g_image_cache[img.dst].spec,
@@ -2169,7 +2169,7 @@ def replace_inline_images(content, inline_images):
         html_img_attributes = profile.thumb_html_img_attributes
         if html_img_attributes:
             for prof_attr_name, prof_attr_value in html_img_attributes.items():
-                extra_attributes += ' {}="{}"'.format(
+                extra_attributes += ' {}="{}"'.format(  # noqa: UP032
                     prof_attr_name, prof_attr_value.format(i=image)
                 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ markdown = [
 [tool.pdm.dev-dependencies]
 lint = [
     "invoke>=2.2.0",
-    "ruff>=0.2",
+    "ruff>=0.3,<0.4",
 ]
 test = [
     "markdown>=3.4",


### PR DESCRIPTION
Some code changes are needed to comply with Ruff 0.3.x, but those changes make the code less readable, so I added `NOQA` exceptions for those two spots.