### PR TITLE
Bump pillow version to 10.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pelican>=4.5",
     "beautifulsoup4~=4.12.2",
     "piexif~=1.1.3",
-    "Pillow~=10.0.1",
+    "Pillow~=10.3.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Addresses security vulnerabilities:
* [CVE-2024-28219: Pillow buffer overflow vulnerability](https://github.com/advisories/GHSA-44wm-f244-xhp3) fixed on Pillow == 10.3.0
* [CVE-2023-50447: Arbitrary Code Execution in Pillow](https://github.com/advisories/GHSA-3f63-hfp8-52jq) fix on Pillow == 10.2.0
