### PR TITLE
Use only the first output path we get

### DIFF
--- a/pelican/plugins/photos/photos.py
+++ b/pelican/plugins/photos/photos.py
@@ -1708,7 +1708,8 @@ def initialized(pelican: Pelican):  # noqa: PLR0915
     global pelican_settings
     pelican_settings = pelican.settings
     global pelican_output_path
-    pelican_output_path = pelican.output_path
+    if pelican_output_path is None:
+        pelican_output_path = pelican.output_path
     global g_profiles
     g_profiles = {}
     default_profile = Profile(


### PR DESCRIPTION
Some plugins like the i18n subsites plugin change the settings or the output path to generate different pages for different languages. We only use the first output path and reuse the images for all languages.

Refs #93 