### PR TITLE
Import photos_macros with context in example gallery

### DIFF
--- a/examples/themes/notmyidea_photos/templates/article.html
+++ b/examples/themes/notmyidea_photos/templates/article.html
@@ -36,7 +36,7 @@
       {% if article.photo_gallery %}
       <!-- >>>> Start >>>>> PHOTO plugin: article gallery >>>>>>>>> -->
       <div class="gallery">
-        {% import "photos_macros.html" as photos_macros %}
+        {% import "photos_macros.html" as photos_macros with context %}
 
         <div class="gallery">
             {% for title, gallery in article.photo_gallery %}

--- a/examples/themes/notmyidea_photos/templates/inline_gallery.html
+++ b/examples/themes/notmyidea_photos/templates/inline_gallery.html
@@ -1,5 +1,5 @@
 <!-- >>>> Start >>>>> PHOTO plugin: inline_gallery template >>>>>>>>> -->
-{% import "photos_macros.html" as photos_macros %}
+{% import "photos_macros.html" as photos_macros with context %}
 
 <div class="gallery">
     {% for title, gallery in galleries %}

--- a/examples/themes/notmyidea_photos/templates/page.html
+++ b/examples/themes/notmyidea_photos/templates/page.html
@@ -23,7 +23,7 @@
     {% if page.photo_gallery %}
     <!-- >>>> Start >>>>> PHOTO plugin: page gallery >>>>>>>>> -->
     <div class="gallery">
-        {% import "photos_macros.html" as photos_macros %}
+        {% import "photos_macros.html" as photos_macros with context %}
         <div class="gallery">
             {% for title, gallery in page.photo_gallery %}
                 {{ photos_macros.gallery(title, gallery, 'Default caption') }}


### PR DESCRIPTION
It is needed to use {{ SITEURL }} in photos_macros.html. Otherwise gallery is broken on webpages not located at /. Alternatively, one could pass SITEURL as a parameter to the macro, but I think there is no harm done here by using `with context`.